### PR TITLE
Add global text reveal animation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { Card, CardContent } from '@/components/ui/card.jsx'
 import { Mail, Youtube, ExternalLink } from 'lucide-react'
 import './App.css'
+import { useTextReveal } from '@/hooks/use-text-reveal.js'
 
 import { AboutSection } from '@/components/AboutSection.jsx'
 import { ArtifactsSection } from '@/components/ArtifactsSection.jsx'
@@ -12,6 +13,8 @@ import { SiteHeader } from '@/components/Header.jsx'
 import { TestimonialsSection } from '@/components/TestimonialsSection.jsx'
 
 function App() {
+  useTextReveal()
+
   return (
     <div className="app-background relative min-h-screen text-black font-mono">
       <div className="app-background__noise" aria-hidden="true" />

--- a/src/components/AboutSection.jsx
+++ b/src/components/AboutSection.jsx
@@ -43,6 +43,7 @@ export function AboutSection() {
               src="https://github.com/iliawerner/iliawerner/raw/fc3ee65c725080ad7d99eb3bb4c59afba1970a3c/podcast.png"
               alt="Portrait of Ilia Werner"
               className="w-full max-w-sm lg:max-w-none h-full object-cover rounded-lg"
+              data-text-reveal-target="true"
               width="640"
               height="640"
             />
@@ -82,6 +83,7 @@ export function AboutSection() {
                     src={`https://i.ytimg.com/vi/${id}/hqdefault.jpg`}
                     alt={`${title} video thumbnail`}
                     className="w-full h-full object-cover"
+                    data-text-reveal-target="true"
                     loading="lazy"
                   />
                   <div className="absolute inset-0 flex items-center justify-center bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity">

--- a/src/components/ArtifactsSection.jsx
+++ b/src/components/ArtifactsSection.jsx
@@ -43,8 +43,8 @@ export function ArtifactsSection() {
                     {title}
                   </h3>
                   <p className="text-base sm:text-lg leading-relaxed">{description}</p>
-                  <div className="mt-auto text-2xl sm:text-3xl font-bold" aria-label={`Price ${price}`}>
-                    {price}
+                  <div className="mt-auto" aria-label={`Price ${price}`}>
+                    <span className="block text-2xl sm:text-3xl font-bold">{price}</span>
                   </div>
                 </CardContent>
               </Card>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -7,7 +7,7 @@ export function SiteHeader() {
         <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4">
           <div className="flex-shrink-0">
             <img
-              src="https://static.tildacdn.com/tild3361-3837-4265-a436-383139323065/photo.svg"
+              src="/photo.svg"
               alt="DELO Studio logo"
               className="h-8"
               width="128"

--- a/src/components/SiteFooter.jsx
+++ b/src/components/SiteFooter.jsx
@@ -3,7 +3,10 @@ export function SiteFooter() {
     <footer className="bg-black text-white" role="contentinfo">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4">
-          <p className="text-sm uppercase tracking-wide text-center w-full">
+          <p
+            className="text-sm uppercase tracking-wide text-center w-full"
+            data-text-reveal-opt-out="true"
+          >
             © 2025 DELO STUDIO LTD. ALL RIGHTS RESERVED.
           </p>
         </div>

--- a/src/hooks/use-text-reveal.js
+++ b/src/hooks/use-text-reveal.js
@@ -23,7 +23,10 @@ const TEXT_SELECTOR = [
   "td",
   "summary",
   "caption"
-].join(",")
+]
+
+const BASE_TEXT_SELECTOR = TEXT_SELECTOR.join(",")
+const TARGET_SELECTOR = `${BASE_TEXT_SELECTOR},[data-text-reveal-target]`
 
 const STAGGER_DELAY_MS = 60
 const OBSERVER_OPTIONS = {
@@ -40,9 +43,17 @@ function isElementEligible(element) {
     return false
   }
 
-  const text = element.textContent?.trim()
-  if (!text) {
+  if (element.closest("[data-text-reveal-opt-out]")) {
     return false
+  }
+
+  const hasForcedTarget = element.hasAttribute("data-text-reveal-target")
+
+  if (!hasForcedTarget) {
+    const text = element.textContent?.trim()
+    if (!text) {
+      return false
+    }
   }
 
   const styles = window.getComputedStyle(element)
@@ -102,14 +113,14 @@ export function useTextReveal() {
         return
       }
 
-      if (node.matches(TEXT_SELECTOR)) {
+      if (node.matches(TARGET_SELECTOR)) {
         registerElement(node)
       }
 
-      node.querySelectorAll(TEXT_SELECTOR).forEach(registerElement)
+      node.querySelectorAll(TARGET_SELECTOR).forEach(registerElement)
     }
 
-    document.querySelectorAll(TEXT_SELECTOR).forEach(registerElement)
+    document.querySelectorAll(TARGET_SELECTOR).forEach(registerElement)
 
     const mutationObserver = new MutationObserver((mutations) => {
       for (const mutation of mutations) {

--- a/src/hooks/use-text-reveal.js
+++ b/src/hooks/use-text-reveal.js
@@ -8,7 +8,6 @@ const TEXT_SELECTOR = [
   "h5",
   "h6",
   "p",
-  "li",
   "dt",
   "dd",
   "blockquote",

--- a/src/hooks/use-text-reveal.js
+++ b/src/hooks/use-text-reveal.js
@@ -1,0 +1,102 @@
+import { useEffect } from "react"
+
+const TEXT_SELECTOR = [
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "p",
+  "li",
+  "dt",
+  "dd",
+  "blockquote",
+  "figcaption",
+  "span",
+  "small",
+  "strong",
+  "em",
+  "label",
+  "a",
+  "button",
+  "th",
+  "td",
+  "summary",
+  "caption"
+].join(",")
+
+function isElementEligible(element) {
+  if (!(element instanceof HTMLElement)) {
+    return false
+  }
+
+  if (element.dataset.textReveal === "true") {
+    return false
+  }
+
+  const text = element.textContent?.trim()
+  if (!text) {
+    return false
+  }
+
+  const styles = window.getComputedStyle(element)
+  if (styles.visibility === "hidden" || styles.display === "none") {
+    return false
+  }
+
+  return true
+}
+
+export function useTextReveal() {
+  useEffect(() => {
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    let order = 0
+
+    const applyAnimation = (element) => {
+      if (!isElementEligible(element)) {
+        return
+      }
+
+      element.dataset.textReveal = "true"
+
+      if (prefersReducedMotion) {
+        element.classList.add("text-reveal--no-motion")
+        return
+      }
+
+      element.style.setProperty("--text-reveal-delay", `${order * 60}ms`)
+      element.classList.add("text-reveal")
+      order += 1
+    }
+
+    const applyToNode = (node) => {
+      if (!(node instanceof Element)) {
+        return
+      }
+
+      if (node.matches(TEXT_SELECTOR)) {
+        applyAnimation(node)
+      }
+
+      node.querySelectorAll(TEXT_SELECTOR).forEach(applyAnimation)
+    }
+
+    document.querySelectorAll(TEXT_SELECTOR).forEach(applyAnimation)
+
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        mutation.addedNodes.forEach((node) => {
+          applyToNode(node)
+        })
+      }
+    })
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true
+    })
+
+    return () => observer.disconnect()
+  }, [])
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,52 @@
+:root {
+  --text-reveal-duration: 0.72s;
+  --text-reveal-stagger: 60ms;
+}
+
+.text-reveal,
+.text-reveal--no-motion {
+  will-change: opacity, transform, filter;
+}
+
+.text-reveal {
+  opacity: 0;
+  transform: translateY(0.45em);
+  filter: blur(10px);
+  animation: text-reveal var(--text-reveal-duration) var(--text-reveal-delay, 0ms)
+      cubic-bezier(0.6, 0.01, 0.05, 1) forwards,
+    text-reveal-color 0.6s calc(var(--text-reveal-delay, 0ms) + 0.18s)
+      cubic-bezier(0.38, 0.005, 0.215, 1) forwards;
+}
+
+.text-reveal--no-motion {
+  opacity: 1;
+  transform: none;
+  filter: none;
+}
+
+@keyframes text-reveal {
+  0% {
+    opacity: 0;
+    transform: translateY(0.45em);
+    filter: blur(10px);
+  }
+  60% {
+    opacity: 1;
+    transform: translateY(-0.05em);
+    filter: blur(3px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+  }
+}
+
+@keyframes text-reveal-color {
+  0% {
+    color: color-mix(in srgb, currentColor 45%, var(--muted-foreground, #777) 55%);
+  }
+  100% {
+    color: currentColor;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -12,7 +12,12 @@
   opacity: 0;
   transform: translateY(0.45em);
   filter: blur(10px);
-  animation: text-reveal var(--text-reveal-duration) var(--text-reveal-delay, 0ms)
+  color: color-mix(in srgb, currentColor 45%, var(--muted-foreground, #777) 55%);
+}
+
+.text-reveal--visible {
+  animation:
+    text-reveal var(--text-reveal-duration) var(--text-reveal-delay, 0ms)
       cubic-bezier(0.6, 0.01, 0.05, 1) forwards,
     text-reveal-color 0.6s calc(var(--text-reveal-delay, 0ms) + 0.18s)
       cubic-bezier(0.38, 0.005, 0.215, 1) forwards;

--- a/src/index.css
+++ b/src/index.css
@@ -3,15 +3,9 @@
   --text-reveal-stagger: 60ms;
 }
 
-.text-reveal,
-.text-reveal--no-motion {
-  will-change: opacity, transform, filter;
-}
-
 .text-reveal {
   opacity: 0;
-  transform: translateY(0.45em);
-  filter: blur(10px);
+  transform: translateY(0.35em);
   color: color-mix(in srgb, currentColor 45%, var(--muted-foreground, #777) 55%);
 }
 
@@ -23,27 +17,29 @@
       cubic-bezier(0.38, 0.005, 0.215, 1) forwards;
 }
 
+
+.text-reveal,
+.text-reveal--no-motion {
+  will-change: opacity, transform;
+}
+
 .text-reveal--no-motion {
   opacity: 1;
   transform: none;
-  filter: none;
 }
 
 @keyframes text-reveal {
   0% {
     opacity: 0;
-    transform: translateY(0.45em);
-    filter: blur(10px);
+    transform: translateY(0.35em);
   }
   60% {
     opacity: 1;
     transform: translateY(-0.05em);
-    filter: blur(3px);
   }
   100% {
     opacity: 1;
     transform: translateY(0);
-    filter: blur(0);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a reusable hook that applies staged reveal animations to all textual elements on the page
- style the reveal with blur and color easing, including reduced-motion handling
- initialize the animation hook from the root App component so new content also animates

## Testing
- pnpm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e192462b888331ba3369a3abcb6f24